### PR TITLE
メッセージ削除機能の修正

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -17,7 +17,7 @@ class MessagesController < ApplicationController
   def destroy
     message = Message.find(params[:id])
     message.destroy
-    redirect_to user_path
+    redirect_to "/users/#{message.user_id}"
   end
 
   def edit


### PR DESCRIPTION
#What
　メッセージ削除機能のパスに問題があったため修正した

#Why
　メッセージが問題なく削除できるようにするため