### PR TITLE
S3へのアップロードを修正するためのコードの解消

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]


### PR DESCRIPTION
#What
　S3へのアップロードが可能になったので、コードを元の状態に修正した

#Why
　コードを残すとエラーが発生してしまうため